### PR TITLE
Add Support for Context Arrays in Logging

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,8 @@
     "require": {
         "php": ">=8.1",
         "ext-json": "*",
-        "spiral/goridge": "^3.1 || ^4.0"
+        "spiral/goridge": "^3.1 || ^4.0",
+        "roadrunner-php/roadrunner-api-dto": "^1.4"
     },
     "autoload": {
         "psr-4": {

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,13 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="vendor/autoload.php" backupGlobals="false"
          colors="true" processIsolation="false" stopOnFailure="false" stopOnError="false" stderr="true"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.0/phpunit.xsd" cacheDirectory=".phpunit.cache"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.4/phpunit.xsd" cacheDirectory=".phpunit.cache"
          backupStaticProperties="false">
-    <coverage>
-        <include>
-            <directory>src</directory>
-        </include>
-    </coverage>
+    <coverage/>
     <testsuites>
         <testsuite name="Test Suite">
             <directory suffix="Test.php">tests</directory>
@@ -17,4 +13,9 @@
         <ini name="error_reporting" value="-1"/>
         <ini name="memory_limit" value="-1"/>
     </php>
+    <source>
+        <include>
+            <directory>src</directory>
+        </include>
+    </source>
 </phpunit>

--- a/src/LogLevel.php
+++ b/src/LogLevel.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace RoadRunner\Logger;
+
+enum LogLevel
+{
+    case Error;
+    case Warning;
+    case Info;
+    case Debug;
+    case Log;
+}

--- a/src/Logger.php
+++ b/src/Logger.php
@@ -132,7 +132,7 @@ final class Logger
     }
 
     /**
-     * @throws \JsonException
+     * @throws \Throwable
      */
     private function prepareValue(mixed $value): string
     {

--- a/src/Logger.php
+++ b/src/Logger.php
@@ -100,7 +100,7 @@ final class Logger
                             'key' => $key,
                             'value' => $this->prepareValue($value),
                         ]);
-                    } catch (\JsonException) {
+                    } catch (\Throwable) {
                         // We can't log this value, so we just skip it.
                     }
                 }

--- a/tests/LoggerTest.php
+++ b/tests/LoggerTest.php
@@ -7,27 +7,24 @@ namespace RoadRunner\Logger\Tests;
 use Mockery as m;
 use RoadRunner\Logger\Logger;
 use RoadRunner\Logger\Exception\LoggerException;
+use RoadRunner\Logger\LogLevel;
+use Spiral\Goridge\RPC\Codec\ProtobufCodec;
 use Spiral\Goridge\RPC\RPCInterface;
 
 final class LoggerTest extends TestCase
 {
     private Logger $logger;
-    /** @var m\LegacyMockInterface|m\MockInterface|RPCInterface */
-    private $rpc;
+    private RpcMock $rpc;
 
     protected function setUp(): void
     {
         parent::setUp();
 
-        $this->rpc = m::mock(RPCInterface::class);
+        $this->rpc = new RpcMock($rpc = m::mock(RPCInterface::class));
 
-        $this->rpc
-            ->shouldReceive('withServicePrefix')
-            ->once()
-            ->with('app')
-            ->andReturnSelf();
+        $this->rpc->assertServicePrefix('app');
 
-        $this->logger = new Logger($this->rpc);
+        $this->logger = new Logger($rpc);
     }
 
     /**
@@ -35,13 +32,25 @@ final class LoggerTest extends TestCase
      */
     public function testErrorCall(): void
     {
-        $this->rpc
-            ->shouldReceive('call')
-            ->once()
-            ->with('Error', 'foo')
-            ->andReturnNull();
-
+        $this->rpc->assertCalled(LogLevel::Error, 'foo');
         $this->logger->error('foo');
+    }
+
+    public function testErrorCallWithContext(): void
+    {
+        $this->rpc
+            ->assertDefinedCodec(ProtobufCodec::class)
+            ->assertCalledWithContext(LogLevel::Error, [
+                'message' => 'some message',
+                'logAttrs' => [
+                    [
+                        'key' => 'foo',
+                        'value' => 'bar',
+                    ],
+                ],
+            ]);
+
+        $this->logger->error('some message', ['foo' => 'bar']);
     }
 
     public function testIfErrorCallFailedThrowAnException(): void
@@ -49,11 +58,7 @@ final class LoggerTest extends TestCase
         $this->expectException(LoggerException::class);
         $this->expectExceptionMessage('Something went wrong');
 
-        $this->rpc
-            ->shouldReceive('call')
-            ->once()
-            ->andThrow(new LoggerException('Something went wrong'));
-
+        $this->rpc->callShouldThrowException(new LoggerException('Something went wrong'));
         $this->logger->error('foo');
     }
 
@@ -62,13 +67,25 @@ final class LoggerTest extends TestCase
      */
     public function testWarningCall(): void
     {
-        $this->rpc
-            ->shouldReceive('call')
-            ->once()
-            ->with('Warning', 'foo')
-            ->andReturnNull();
-
+        $this->rpc->assertCalled(LogLevel::Warning, 'foo');
         $this->logger->warning('foo');
+    }
+
+    public function testWarningCallWithContext(): void
+    {
+        $this->rpc
+            ->assertDefinedCodec(ProtobufCodec::class)
+            ->assertCalledWithContext(LogLevel::Warning, [
+                'message' => 'some message',
+                'logAttrs' => [
+                    [
+                        'key' => 'foo',
+                        'value' => 'bar',
+                    ],
+                ],
+            ]);
+
+        $this->logger->warning('some message', ['foo' => 'bar']);
     }
 
     public function testIfWarningCallFailedThrowAnException(): void
@@ -76,11 +93,7 @@ final class LoggerTest extends TestCase
         $this->expectException(LoggerException::class);
         $this->expectExceptionMessage('Something went wrong');
 
-        $this->rpc
-            ->shouldReceive('call')
-            ->once()
-            ->andThrow(new LoggerException('Something went wrong'));
-
+        $this->rpc->callShouldThrowException(new LoggerException('Something went wrong'));
         $this->logger->warning('foo');
     }
 
@@ -89,13 +102,25 @@ final class LoggerTest extends TestCase
      */
     public function testInfoCall(): void
     {
-        $this->rpc
-            ->shouldReceive('call')
-            ->once()
-            ->with('Info', 'foo')
-            ->andReturnNull();
-
+        $this->rpc->assertCalled(LogLevel::Info, 'foo');
         $this->logger->info('foo');
+    }
+
+    public function testInfoCallWithContext(): void
+    {
+        $this->rpc
+            ->assertDefinedCodec(ProtobufCodec::class)
+            ->assertCalledWithContext(LogLevel::Info, [
+                'message' => 'some message',
+                'logAttrs' => [
+                    [
+                        'key' => 'foo',
+                        'value' => 'bar',
+                    ],
+                ],
+            ]);
+
+        $this->logger->info('some message', ['foo' => 'bar']);
     }
 
     public function testIfInfoCallFailedThrowAnException(): void
@@ -103,11 +128,7 @@ final class LoggerTest extends TestCase
         $this->expectException(LoggerException::class);
         $this->expectExceptionMessage('Something went wrong');
 
-        $this->rpc
-            ->shouldReceive('call')
-            ->once()
-            ->andThrow(new LoggerException('Something went wrong'));
-
+        $this->rpc->callShouldThrowException(new LoggerException('Something went wrong'));
         $this->logger->info('foo');
     }
 
@@ -116,13 +137,25 @@ final class LoggerTest extends TestCase
      */
     public function testDebugCall(): void
     {
-        $this->rpc
-            ->shouldReceive('call')
-            ->once()
-            ->with('Debug', 'foo')
-            ->andReturnNull();
-
+        $this->rpc->assertCalled(LogLevel::Debug, 'foo');
         $this->logger->debug('foo');
+    }
+
+    public function testDebugCallWithContext(): void
+    {
+        $this->rpc
+            ->assertDefinedCodec(ProtobufCodec::class)
+            ->assertCalledWithContext(LogLevel::Debug, [
+                'message' => 'some message',
+                'logAttrs' => [
+                    [
+                        'key' => 'foo',
+                        'value' => 'bar',
+                    ],
+                ],
+            ]);
+
+        $this->logger->debug('some message', ['foo' => 'bar']);
     }
 
     public function testIfDebugCallFailedThrowAnException(): void
@@ -130,11 +163,7 @@ final class LoggerTest extends TestCase
         $this->expectException(LoggerException::class);
         $this->expectExceptionMessage('Something went wrong');
 
-        $this->rpc
-            ->shouldReceive('call')
-            ->once()
-            ->andThrow(new LoggerException('Something went wrong'));
-
+        $this->rpc->callShouldThrowException(new LoggerException('Something went wrong'));
         $this->logger->debug('foo');
     }
 
@@ -143,13 +172,25 @@ final class LoggerTest extends TestCase
      */
     public function testLogCall(): void
     {
-        $this->rpc
-            ->shouldReceive('call')
-            ->once()
-            ->with('Log', 'foo')
-            ->andReturnNull();
-
+        $this->rpc->assertCalled(LogLevel::Log, 'foo');
         $this->logger->log('foo');
+    }
+
+    public function testLogCallWithContext(): void
+    {
+        $this->rpc
+            ->assertDefinedCodec(ProtobufCodec::class)
+            ->assertCalledWithContext(LogLevel::Log, [
+                'message' => 'some message',
+                'logAttrs' => [
+                    [
+                        'key' => 'foo',
+                        'value' => 'bar',
+                    ],
+                ],
+            ]);
+
+        $this->logger->log('some message', ['foo' => 'bar']);
     }
 
     public function testIfLogCallFailedThrowAnException(): void
@@ -157,11 +198,7 @@ final class LoggerTest extends TestCase
         $this->expectException(LoggerException::class);
         $this->expectExceptionMessage('Something went wrong');
 
-        $this->rpc
-            ->shouldReceive('call')
-            ->once()
-            ->andThrow(new LoggerException('Something went wrong'));
-
+        $this->rpc->callShouldThrowException(new LoggerException('Something went wrong'));
         $this->logger->log('foo');
     }
 }

--- a/tests/RpcMock.php
+++ b/tests/RpcMock.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace RoadRunner\Logger\Tests;
+
+use Mockery\MockInterface;
+use PHPUnit\Framework\Assert;
+use RoadRunner\AppLogger\DTO\V1\LogEntry;
+use RoadRunner\Logger\LogLevel;
+
+final class RpcMock
+{
+    public function __construct(
+        private readonly MockInterface $mock,
+    ) {
+    }
+
+    public function assertDefinedCodec(string $codec, int $times = 1): self
+    {
+        $this->mock
+            ->shouldReceive('withCodec')
+            ->times($times)
+            ->with(\Mockery::type($codec))
+            ->andReturnSelf();
+
+        return $this;
+    }
+
+    public function assertServicePrefix(string $prefix, int $times = 1): self
+    {
+        $this->mock
+            ->shouldReceive('withServicePrefix')
+            ->times($times)
+            ->with($prefix)
+            ->andReturnSelf();
+
+        return $this;
+    }
+
+    public function assertCalled(LogLevel $level, string $message, int $times = 1): self
+    {
+        $this->mock
+            ->shouldReceive('call')
+            ->times($times)
+            ->with($level->name, $message)
+            ->andReturnNull();
+
+        return $this;
+    }
+
+    public function callShouldThrowException(\Throwable $e): self
+    {
+        $this->mock
+            ->shouldReceive('call')
+            ->once()
+            ->andThrow($e);
+
+        return $this;
+    }
+
+    public function assertCalledWithContext(LogLevel $level, array $message, int $times = 1): self
+    {
+        $this->mock
+            ->shouldReceive('call')
+            ->times($times)
+            ->with(
+                $level->name . 'WithContext',
+                \Mockery::on(function (LogEntry $logEntry) use ($message): bool {
+                    Assert::assertSame($logEntry->serializeToJsonString(), \json_encode($message));
+                    return true;
+                }),
+            )
+            ->andReturnNull();
+
+        return $this;
+    }
+}


### PR DESCRIPTION
## Overview
This pull request introduces the capability to include single-level associative arrays as context in log messages. Users can now pass an additional array parameter to the logging methods to include custom fields in their logs.

## Changes
- Modified the logging methods (`info`, `warning`, `error`, etc.) to accept a second optional parameter `$context`.
- Ensured that the `$context` array is single-level and only accepts string keys and values to maintain simplicity and compatibility with the RoadRunner logger.
- Updated the internal logic to handle the context array and integrate it into the log output seamlessly.

## Usage Example

```php
$logger->info('User is opening the article', ['article' => '1']);
$logger->info('User is opening the article and is selecting the color', ['article' => '1', 'color' => 'red']);
```

issue [#19](https://github.com/roadrunner-php/issues/issues/19)

---

Looking forward to the community's feedback and suggestions on this improvement.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
    - Introduced a new LogLevel enum for better logging control.
    - Enhanced Logger class to support logging context data.
- **Tests**
    - Added new test methods for logging with context in LoggerTest class.
    - Introduced a new RpcMock class for more efficient RPC mocking in tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->